### PR TITLE
Add core_version_requeriment

### DIFF
--- a/log_stdout.info.yml
+++ b/log_stdout.info.yml
@@ -7,5 +7,6 @@ type: module
 # Information added by Drupal.org packaging script on 2017-08-08
 version: '8.x-1.1'
 core: '8.x'
+core_version_requirement: ^8 || ^9
 project: 'log_stdout'
 datestamp: 1502196546


### PR DESCRIPTION
I check the module with [drupal_check](https://github.com/mglaman/drupal-check) and it seems that the module is compatible with drupal 9.